### PR TITLE
Look deeper for tcl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,8 @@ class VMDBuild(DistutilsBuild):
         # Look in directories specified by $INCLUDE
         searchdirs = [d for d in os.environ.get("INCLUDE", "").split(":")
                       if os.path.isdir(d)]
+        print(os.environ.get("INCLUDE",""))
+        print(searchdirs)
         # Also look in the directories gcc does
         try:
             out = check_output(r"echo | gcc -E -Wp,-v - 2>&1 | grep '^\s.*'",
@@ -79,18 +81,18 @@ class VMDBuild(DistutilsBuild):
             searchdirs.extend([d.strip() for d in out if os.path.isdir(d.strip())])
         except: pass
         searchdirs.insert(0, os.path.join(pydir, "include"))
-
+        print(searchdirs)
         # Find the actual file
         out = b""
         try:
             out = check_output(["find", "-H"]
                                + searchdirs
-                               + ["-maxdepth", "1",
+                               + ["-maxdepth", "2",
                                   "-name", incfile],
                                close_fds=True,
                                stderr=open(os.devnull, 'wb'))
         except: pass
-
+        print(out)
         incdir = os.path.split(out.decode("utf-8").split("\n")[0])[0]
         if not glob(os.path.join(incdir, incfile)): # Glob allows wildcards
             incdir = os.path.join(pydir, "include", incfile)

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ class VMDBuild(DistutilsBuild):
             searchdirs.extend([d.strip() for d in out if os.path.isdir(d.strip())])
         except: pass
         searchdirs.insert(0, os.path.join(pydir, "include"))
+        
         # Find the actual file
         out = b""
         try:
@@ -89,7 +90,7 @@ class VMDBuild(DistutilsBuild):
                                close_fds=True,
                                stderr=open(os.devnull, 'wb'))
         except: pass
-        print(out)
+        
         incdir = os.path.split(out.decode("utf-8").split("\n")[0])[0]
         if not glob(os.path.join(incdir, incfile)): # Glob allows wildcards
             incdir = os.path.join(pydir, "include", incfile)

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,6 @@ class VMDBuild(DistutilsBuild):
         # Look in directories specified by $INCLUDE
         searchdirs = [d for d in os.environ.get("INCLUDE", "").split(":")
                       if os.path.isdir(d)]
-        print(os.environ.get("INCLUDE",""))
-        print(searchdirs)
         # Also look in the directories gcc does
         try:
             out = check_output(r"echo | gcc -E -Wp,-v - 2>&1 | grep '^\s.*'",
@@ -81,7 +79,6 @@ class VMDBuild(DistutilsBuild):
             searchdirs.extend([d.strip() for d in out if os.path.isdir(d.strip())])
         except: pass
         searchdirs.insert(0, os.path.join(pydir, "include"))
-        print(searchdirs)
         # Find the actual file
         out = b""
         try:

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ class VMDBuild(DistutilsBuild):
             searchdirs.extend([d.strip() for d in out if os.path.isdir(d.strip())])
         except: pass
         searchdirs.insert(0, os.path.join(pydir, "include"))
-        
+
         # Find the actual file
         out = b""
         try:
@@ -90,7 +90,7 @@ class VMDBuild(DistutilsBuild):
                                close_fds=True,
                                stderr=open(os.devnull, 'wb'))
         except: pass
-        
+
         incdir = os.path.split(out.decode("utf-8").split("\n")[0])[0]
         if not glob(os.path.join(incdir, incfile)): # Glob allows wildcards
             incdir = os.path.join(pydir, "include", incfile)


### PR DESCRIPTION
On Ubuntu, tcl headers are found in /usr/include/tcl8.5, rather than /usr/include. As a result, my build failed until I made it look a little deeper into the directory tree to find a tcl.h.