### PR TITLE
Actually compile a dynamic PIC library

### DIFF
--- a/vmd/vmd_src/configure
+++ b/vmd/vmd_src/configure
@@ -2038,6 +2038,15 @@ if ($config_arch eq "LINUXPPC64") {
     # this is to make tcl happy
     # also needed for plugins
     $system_libs .= " -ldl";
+    
+    if ($config_shared) {
+      $arch_opt_flag   .= " -fPIC";
+      $arch_copts      .= " -fPIC";
+      $arch_nvccflags  .= " -Xcompiler -fPIC";
+      $arch_lopts      .= " -shared";
+      $arch_cppopts    .= " -DVMD_SHARED";
+    }
+
 }
 
 if ($config_arch eq "MACOSX") {


### PR DESCRIPTION
I think this will fix Austin's issue with python refusing to load a non-dynamic library (https://github.com/Eigenstate/vmd-python/issues/22#issuecomment-468037883). For whatever reason, VMD's configure didn't have the PIC compiler options for a shared library, probably because nobody tried to do this before.