### PR TITLE
A few changes to get vmd-python to compile on my system

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ link successfully:
 In Debian, these are provided in `libegl1-mesa-dev`, `mesa-common-dev`,
 and `libopengl0` packages. To build:
 
-    python setup.py --egl build
+    python setup.py build --egl
     python setup.py install
 
 Please file issues if you have problems with this!!

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ class VMDBuild(DistutilsBuild):
             os.environ["LDFLAGS"] = ""
 
         self.libdirs = self._get_libdirs()
+        
         DistutilsBuild.finalize_options(self)
 
     #==========================================================================
@@ -113,6 +114,7 @@ class VMDBuild(DistutilsBuild):
         osdirs = dirout.decode("utf-8").replace("libraries: =", "").split(":")
         searchdirs.extend([os.path.abspath(_) for _ in osdirs if
                            os.path.isdir(_)])
+
         return searchdirs
 
     #==========================================================================
@@ -215,6 +217,7 @@ class VMDBuild(DistutilsBuild):
         pythonldflag = os.path.splitext(pylibname)[0] if pylibdir else None
 
         suffix = ".dylib" if "Darwin" in platform.system() else ".so"
+
         # Check a library with appropriate extension actually exists.
         # If not, try to find a libpython and use that
         if pylibname is None or pylibdir is None or \
@@ -224,7 +227,6 @@ class VMDBuild(DistutilsBuild):
             print("Finding python location via fallback method...")
             pylibname = "libpython%s*" % sysconfig.get_python_version()
             candidate_libs = self._find_library_dir(pylibname)
-            print candidate_libs
             libs = sorted(glob(os.path.join(candidate_libs, pylibname)),
                           key=len)
             pylibdir, pythonldflag = os.path.split(libs[-1])

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ class VMDBuild(DistutilsBuild):
             os.environ["LDFLAGS"] = ""
 
         self.libdirs = self._get_libdirs()
-
         DistutilsBuild.finalize_options(self)
 
     #==========================================================================
@@ -114,7 +113,6 @@ class VMDBuild(DistutilsBuild):
         osdirs = dirout.decode("utf-8").replace("libraries: =", "").split(":")
         searchdirs.extend([os.path.abspath(_) for _ in osdirs if
                            os.path.isdir(_)])
-
         return searchdirs
 
     #==========================================================================
@@ -184,7 +182,7 @@ class VMDBuild(DistutilsBuild):
                                close_fds=True,
                                stderr=open(os.devnull, 'wb'))
             libdir = out.decode("utf-8").splitlines()[0]
-            libdir = libdir[:libdir.index(libfile)]
+            libdir = os.path.dirname(libdir)
         except: pass
 
         if glob(os.path.join(libdir, libfile)): # Glob allows wildcards
@@ -217,7 +215,6 @@ class VMDBuild(DistutilsBuild):
         pythonldflag = os.path.splitext(pylibname)[0] if pylibdir else None
 
         suffix = ".dylib" if "Darwin" in platform.system() else ".so"
-
         # Check a library with appropriate extension actually exists.
         # If not, try to find a libpython and use that
         if pylibname is None or pylibdir is None or \
@@ -227,6 +224,7 @@ class VMDBuild(DistutilsBuild):
             print("Finding python location via fallback method...")
             pylibname = "libpython%s*" % sysconfig.get_python_version()
             candidate_libs = self._find_library_dir(pylibname)
+            print candidate_libs
             libs = sorted(glob(os.path.join(candidate_libs, pylibname)),
                           key=len)
             pylibdir, pythonldflag = os.path.split(libs[-1])

--- a/vmd/install.sh
+++ b/vmd/install.sh
@@ -48,7 +48,7 @@ cd $vmd_src/vmd_src
 $vmd_src/vmd_src/configure
 cd $vmd_src/vmd_src/src
 make veryclean
-make libvmd.so
+make -j libvmd.so
 make install
 
 # Clean up built files in src dir

--- a/vmd/plugins/Make-arch
+++ b/vmd/plugins/Make-arch
@@ -23,7 +23,7 @@ LINUX:
 	"AR = $(AR)" \
 	"NM = $(NM) -p" \
 	"RANLIB = touch" \
-	"SHLD = gcc -shared"
+	"SHLD = $(CXX) -shared"
 
 LINUXAMD64:
 	$(MAKE) dynlibs staticlibs bins \
@@ -40,7 +40,7 @@ LINUXAMD64:
 	"AR = $(AR)" \
 	"NM = $(NM) -p" \
 	"RANLIB = touch" \
-	"SHLD = $(CC) -shared"
+	"SHLD = $(CXX) -shared"
 
 LINUXPPC64:
 	$(MAKE) dynlibs staticlibs bins \
@@ -57,7 +57,7 @@ LINUXPPC64:
 	"AR = $(AR)" \
 	"NM = $(NM) -p" \
 	"RANLIB = touch" \
-	"SHLD = $(CC) -shared"
+	"SHLD = $(CXX) -shared"
 
 MACOSX:
 	$(MAKE) dynlibs staticlibs bins \


### PR DESCRIPTION
On my machine, the current setup was unable to find libpython2.7 through the fallback mechanism, since it was searching for a libpython*2.7, and didn't come up with a valid libdir.

I also noticed that dlopen was frequently failing for the C++ molfile plugins, which was caused by their being linked by the C compiler (usually gcc) instead of the C++ compiler.