### PR TITLE
Fix installation into VirtualEnv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -234,18 +234,21 @@ class VMDBuild(DistutilsBuild):
             return "-undefined dynamic_lookup"
 
         # See if we can get it from sysconfig
+        pylibdir = pythonldflag = None
         pylibname = sysconfig.get_config_var("LIBRARY") # "libpython3.6m.a"
-        pylibdir = sysconfig.get_config_var("LIBDIR") # "~/miniconda/lib"
-        pythonldflag = os.path.splitext(pylibname)[0] if pylibdir else None
-
         suffix = ".so"
+        if pylibname is not None:
+            soname = os.path.splitext(pylibname)[0] + suffix
+            for libdirvar in ("LIBDIR", "LIBPL"):
+                libdir = sysconfig.get_config_var(libdirvar) # "~/miniconda/lib"
+                if os.path.isfile(os.path.join(libdir, soname)):
+                    pylibdir = libdir
+                    pythonldflag = os.path.splitext(soname)[0]
+                    break
 
         # Check a library with appropriate extension actually exists.
         # If not, try to find a libpython and use that
-        if pylibname is None or pylibdir is None or \
-                not os.path.isfile(os.path.join(pylibdir, pythonldflag)
-                                   + suffix):
-
+        if pylibname is None or pylibdir is None:
             print("Finding python location via fallback method...")
             pylibname = "libpython%s*" % sysconfig.get_python_version()
             candidate_libs = self._find_library_dir(pylibname)


### PR DESCRIPTION
Hi!

I had some troubles installing vmd-python into VirtualEnv (sorry, not a big fan of Conda) on Ubuntu 18.04:

```
$ python3 -m venv test_venv  # Create empty environment
$ . test_venv/bin/activate
$ pip install numpy
Successfully installed numpy-1.16.2
$ python setup.py install
running install
running build
Finding libraries...
  Newer libtcl8.6 used
   LIB: libtcl8.6.so -> /usr/lib/x86_64-linux-gnu/
   INC: tcl.h -> /usr/include/tcl8.6/
   LIB: libsqlite3.so -> /usr/lib/x86_64-linux-gnu/
   INC: sqlite3.h -> /usr/include/
   LIB: libexpat.so -> /usr/lib/x86_64-linux-gnu/
   INC: expat.h -> /usr/include/
   LIB: libnetcdf.so -> /usr/lib/x86_64-linux-gnu/
   INC: netcdf.h -> /usr/include/
Finding python location via fallback method...
Traceback (most recent call last):
  File "setup.py", line 458, in <module>
    'test': VMDTest,
  File "/tmp/test_venv/lib/python3.6/site-packages/setuptools/__init__.py", line 129, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.6/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.6/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "setup.py", line 424, in run
    self.run_command("build")
  File "/usr/lib/python3.6/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "setup.py", line 71, in run
    self.compile_vmd()
  File "setup.py", line 85, in compile_vmd
    self.set_environment_variables(pydir)
  File "setup.py", line 327, in set_environment_variables
    pythonldflag = self._get_python_ldflag(pydir)
  File "setup.py", line 251, in _get_python_ldflag
    candidate_libs = self._find_library_dir(pylibname)
  File "setup.py", line 216, in _find_library_dir
    libfile);
RuntimeError: Could not find library 'libpython3.6*.so' in standard library directories. Update $LD_LIBRARY_PATH to include the directory containing this file, or make sure it is present on your system
```

The problem is that in case of VirtualEnv (and, I guess, system-wide Python), `sysconfig.get_config_var("LIBDIR")` does not return the directory where libpythonX.Y.so is stored. 

Unable to find a more robust way to deal with this issue, I've adapted [this StackOverflow answer](https://stackoverflow.com/a/50357801/929437) to check both `LIBDIR` and `LIBPL` paths. It works with both VirtualEnv (Python 3.6) and Anaconda (Python 3.7) for me.

I'm not sure you want this additional complexity if you're not planning to support VirtualEnv as an installation method, but IMHO it's nice to have.

