### PR TITLE
Add waitfor back to molecule.write

### DIFF
--- a/vmd/vmd_src/src/py_molecule.C
+++ b/vmd/vmd_src/src/py_molecule.C
@@ -486,10 +486,10 @@ static PyObject* py_mol_write(PyObject *self, PyObject *args, PyObject *kwargs)
   // Handle legacy keywords beg, end, skip, but emit DeprecationWarning
   handle_legacy_keywords(kwargs);
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "iss|iiiiO!:molecule.write",
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "iss|iiiiO:molecule.write",
                                    (char**) kwlist, &molid, &type, &filename,
                                    &spec.first, &spec.last, &spec.stride, &spec.waitfor,
-                                   &Atomsel_Type, &selobj))
+                                   &selobj))
     return NULL;
 
   if (!(app = get_vmdapp()))

--- a/vmd/vmd_src/src/py_molecule.C
+++ b/vmd/vmd_src/src/py_molecule.C
@@ -488,7 +488,7 @@ static PyObject* py_mol_write(PyObject *self, PyObject *args, PyObject *kwargs)
 
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "iss|iiiiO!:molecule.write",
                                    (char**) kwlist, &molid, &type, &filename,
-                                   &spec.first, &spec.last, &spec.stride, &spec.waitfor
+                                   &spec.first, &spec.last, &spec.stride, &spec.waitfor,
                                    &Atomsel_Type, &selobj))
     return NULL;
 

--- a/vmd/vmd_src/src/py_molecule.C
+++ b/vmd/vmd_src/src/py_molecule.C
@@ -460,14 +460,15 @@ static const char mol_write_doc[] =
 "    filename (str): Path to coordinate data\n"
 "    first (int): First frame to read. Defaults to 0 (first frame)\n"
 "    last (int): Last frame to read, or -1 for the end. Defaults to -1\n"
-"    stride (int): Frame stride. Defaults to 1 (read all frames)\n"
+"    stride (int): Frame stride. Defaults to 1 (write all frames)\n"
+"    waitfor (int): Number of frames to wait for before returning control. Defaults to -1 (wait for all frames)"
 "    selection (atomsel): Atom indices to write. Defaults to all atoms."
 "Returns:\n"
 "    (int): Number of frames written";
 static PyObject* py_mol_write(PyObject *self, PyObject *args, PyObject *kwargs)
 {
   const char *kwlist[] = {"molid", "filetype", "filename", "first", "last",
-                          "stride", "selection", NULL};
+                          "stride", "waitfor", "selection", NULL};
   PyObject *selobj = NULL;
   char *filename, *type;
   int numframes, molid;
@@ -485,9 +486,9 @@ static PyObject* py_mol_write(PyObject *self, PyObject *args, PyObject *kwargs)
   // Handle legacy keywords beg, end, skip, but emit DeprecationWarning
   handle_legacy_keywords(kwargs);
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "iss|iiiO!:molecule.write",
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "iss|iiiiO!:molecule.write",
                                    (char**) kwlist, &molid, &type, &filename,
-                                   &spec.first, &spec.last, &spec.stride,
+                                   &spec.first, &spec.last, &spec.stride, &spec.waitfor
                                    &Atomsel_Type, &selobj))
     return NULL;
 


### PR DESCRIPTION
As it stands right now, calling `Molecule.write` fails, because the underlying molecule.write call doesn't match the spec, since somewhere along the way the underlying `molecule.write` lost the waitfor parameter. This adds it back, but does not change the default behavior (write everything before returning).