### PR TITLE
Add a check to setting a value from an array.

### DIFF
--- a/vmd/vmd_src/src/py_atomsel.C
+++ b/vmd/vmd_src/src/py_atomsel.C
@@ -434,6 +434,12 @@ static int build_set_values(const void* list, int num_atoms, PyObject* val,
   // Determine if passed PyObject is an array
   is_array = (PySequence_Check(val) && !is_pystring(val)) ? 1 : 0;
 
+  //If it is an array, check to make sure it matches the length of the selection.
+  if (is_array && PySequence_Length(val) > 1 && PySequence_Length(val) != atomSel->selected ) {
+    PyErr_SetString(PyExc_ValueError, "sequence length does not match the number of selected atoms");
+    return 1;
+  }
+  
   for (i = 0; i < num_atoms; i++) {
     // Continue if atom is not part of selection
     if (!flgs[i])


### PR DESCRIPTION
This gives the user a clearer error message if they get something wrong, like I sometimes do. I had tried setting the beta column from an array of the wrong size, and the error message it gave was less than informative. This extra check defends against this user error.